### PR TITLE
docs: 정보 정확성 규칙 보강 및 문서 작성 언어 규칙 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,29 +19,44 @@
 
 ### Information Accuracy
 
-- Do not speculate. Verify first, then speak based on confirmed results
-  - Never present unverified information as fact. Always cite sources or evidence
+- Do not speculate. Verify first, then respond based on confirmed results.
+  - Never present unverified information as fact.
   - **Classify the type of factual claim first**:
     1) **Internal codebase facts**: Local code, configuration, logs
     2) **External public facts**: Vendor features, standards, public announcements, version policies
+  - **Apply verification strength by claim criticality**:
+    - External verification is **mandatory** for:
+      - definitive claims ("X is supported", "Y is deprecated", "policy requires Z")
+      - version/policy/lifecycle statements
+      - numeric claims (performance, percentages, timelines, limits)
+    - For non-decisive explanatory statements, avoid definitive wording and mark uncertainty when verification is pending.
+  - **Use evidence format based on claim type**:
+    - **Internal codebase facts**: cite concrete local evidence (file path, config key, log excerpt/timestamp, command output summary).
+    - **External public facts**: cite at least one official primary source URL and include verification date (YYYY-MM-DD).
   - **For external public facts, perform external verification**:
     - Priority hierarchy:
       1. Official primary sources (official docs, official blog/release notes, official announcements)
       2. Reliable secondary sources (major news/tech media)
       3. Internal knowledge (use only as fallback when verification fails)
-    - Include at least 1 official source and verification date (YYYY-MM-DD) when making definitive statements
-  - **When sources conflict**: Prioritize the most recent official primary source, and explicitly note the conflict
-  - **When external verification is impossible**: Do not make definitive statements. Respond with:
-    - "Currently unable to verify externally. Verification needed."
-  - **Mark internal knowledge as "training data estimate"** until verified
-  - **Distinguish terminology**: Do not conflate "standard" and "official feature"
-  - When estimating numbers, effects, timelines, etc., clearly state the basis and assumptions
-  - Use phrases like "roughly", "typically" only after verified information, not as substitutes for verification
-  - When uncertain, explicitly state "needs verification" or "let me search for this first"
-  - State facts verified against the actual codebase. Do not include speculative numbers or effects without measurement basis
-  - When proposing optimization or improvement strategies, clearly distinguish the scope of impact (e.g., Terraform apply time vs VM startup time)
-  - When writing percentage-based estimates, do not simply add independent percentages. Explain the calculation basis
-- Consider the user's current project phase and priorities before making suggestions. Do not propose advanced features (monitoring, CI/CD integration, etc.) when foundational work is still in progress
+  - **When sources conflict**:
+    - Prioritize the most recent official primary source and explicitly note the conflict.
+    - If multiple latest official primary sources conflict, or recency is unclear, explicitly state ambiguity, provide a conservative conclusion, and mark that additional verification is required.
+  - **When external verification is impossible**:
+    - Do not make definitive statements. Respond with:
+      - "현재 외부 검증이 불가능하여 단정적으로 답변할 수 없습니다. 검증이 필요합니다."
+  - **Mark internal knowledge as "training data estimate"** until verified.
+  - **Distinguish terminology**: Do not conflate "standard" and "official feature".
+  - When citing any evidence, **mask secrets and sensitive data** (API keys, tokens, credentials, PII) according to Section 3 (Sensitive Information Rules).
+  - When estimating numbers, effects, timelines, or percentages, clearly state basis and assumptions.
+  - Use phrases like "roughly" or "typically" only after verification; never as a substitute for verification.
+  - When uncertain, explicitly state "needs verification" or "let me search for this first".
+  - State facts verified against the actual codebase. Do not include speculative numbers or effects without measurement basis.
+  - When proposing optimization or improvement strategies, clearly distinguish the scope of impact (e.g., Terraform apply time vs VM startup time).
+  - When writing percentage-based estimates, do not simply add independent percentages; explain the calculation basis.
+  - **Mini reporting templates (use as needed)**:
+    - Internal fact template: `Verified internally: <claim>. Evidence: <file path / config key / log timestamp / command summary>.`
+    - External fact template: `Verified externally: <claim>. Source: <official URL>. Verified on: <YYYY-MM-DD>.`
+- Consider the user's current project phase and priorities before making suggestions. Do not propose advanced features (monitoring, CI/CD integration, etc.) when foundational work is still in progress.
 
 ### Task Completion
 


### PR DESCRIPTION
## 배경

이번 작업은 AI 에이전트가 외부 기술/표준에 대해 잘못된 정보를 제공하는 사고를 방지하기 위해 수행되었습니다.

### 사고 경위

사용자가 "Skills"가 Anthropic의 표준 기술인지 질문했을 때, AI 에이전트는 확인 없이 "Skills는 Anthropic의 표준 기술이 아니다"라고 답변했습니다. 그러나 웹 검색 결과, Skills는 Anthropic이 2025년 10월에 공식 런칭한 기능으로 확인되었습니다.

이는 AGENTS.md의 "정보 정확성" 규칙을 위반한 사례입니다:
- "Verify first, then speak" (먼저 검증하고 말한다)
- "Never present unverified information as fact" (검증되지 않은 정보를 사실로 제시하지 않는다)

### 규칙의 모호성

기존 규칙은 다음과 같은 점에서 모호했습니다:

1. **"검증된 정보"의 정의 불명확** - 내부 지식인지, 웹 검색인지, 문서 확인인지 기준이 없음
2. **검색 트리거 없음** - 언제 웹 검색을 해야 하는지 명시되지 않음
3. **외부 기술/표준 구분 없음** - Anthropic, OpenAI 등 외부 조직의 기술에 대한 특별 규칙이 없음
4. **"학습 데이터" vs "검증 필요" 구분 없음** - AI의 내부 지식을 그대로 믿어도 되는지 불명확

## 변경 내용

### 1. 정보 정확성 규칙 보강

- **사실 주장 유형 분류** 추가
  - 내부 코드베이스 사실 vs 외부 공개 사실
- **검증 강도 적용 조건** 추가
  - 결정적 주장, 버전/정책 진술, 수치 주장에만 외부 검증 강제
- **증거 형식 분리** 추가
  - 내부 사실: 파일 경로, 설정 키, 로그 타임스탬프, 명령 요약
  - 외부 사실: 공식 URL + 검증일(YYYY-MM-DD)
- **외부 공개 사실에 대한 외부 검증 의무화**
  - 검증 우선순위: 공식 1차 출처 > 신뢰 가능한 2차 출처 > 내부 지식
- **출처 충돌 시 처리 방법** 추가
  - 최신 공식 1차 출처 우선
  - 동률/불명확 시 "충돌 명시 + 보수적 결론 + 추가 확인 필요"
- **외부 검증 불가 시 응답 템플릿** 한국어로 변경
  - "현재 외부 검증이 불가능하여 단정적으로 답변할 수 없습니다. 검증이 필요합니다."
- **민감정보 마스킹 규칙** 추가
  - 근거 제시 시 비밀값/개인정보는 반드시 마스킹 (Section 3 연결)
- **용어 구분 규칙** 추가 ("표준" vs "공식 기능")
- **미니 보고 템플릿** 추가
  - 내부 사실 템플릿: `Verified internally: <claim>. Evidence: <file path / config key / log timestamp / command summary>.`
  - 외부 사실 템플릿: `Verified externally: <claim>. Source: <official URL>. Verified on: <YYYY-MM-DD>.`

### 2. 문서 작성 언어 규칙 추가

- **규칙 파일(AGENTS.md, SKILL.md)은 영어로 작성**
- **근거**: 같은 내용이라도 영어가 한국어보다 토큰을 덜 사용
- **사용자와의 대화는 한국어로 유지**: 사용자의 모국어 편의성 우선

## Oracle 검토 반영

Oracle 에이전트의 검토를 통해 6가지 개선사항을 추가로 반영했습니다:

1. **검증 강도 적용 조건** - 언제 외부 검증이 강제인지 명확화
2. **내부/외부 증거 형식 분리** - 각 유형에 맞는 증거 제시 방식 명시
3. **한국어 템플릿** - 외부 검증 불가 시 응답을 한국어로 변경
4. **출처 충돌 동률 케이스** - 최신 공식 출처가 복수로 상충하는 경우 처리
5. **민감정보 마스킹 연결** - Section 3(민감정보 규칙)과의 정합성 확보
6. **미니 템플릿 추가** - 실무에서 바로 사용 가능한 보고 형식 제공

## 검토 요청

PR 본문을 검토한 후 머지를 진행해주세요.

## 참고

- Oracle 에이전트의 2차 검토를 거쳐 추가 개선사항을 반영했습니다.