### PR TITLE
docs: 코드 내부 분석 결과의 공식 소스 교차 검증 규칙 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,10 @@ Conflict handling policy:
   - **Use evidence format based on claim type**:
     - **Internal codebase facts**: cite concrete local evidence (file path, config key, log excerpt/timestamp, command output summary).
     - **External public facts**: cite at least one official primary source URL and include verification date (YYYY-MM-DD).
+  - **Do not infer external project intent from code internals alone**:
+    - Variable names, constants, and internal identifiers may not reflect the project's official naming, direction, or intent (e.g., `PLUGIN_NAME` vs `LEGACY_PLUGIN_NAME` may be misleading).
+    - Always cross-check conclusions drawn from code analysis against official sources (GitHub repo About/README, release notes, official docs) before presenting them as fact.
+    - When code internals and official sources conflict, trust the official source and note the discrepancy.
   - **For external public facts, perform external verification**:
     - Priority hierarchy:
       1. Official primary sources (official docs, official blog/release notes, official announcements)


### PR DESCRIPTION
## Summary

- Information Accuracy 섹션에 "Do not infer external project intent from code internals alone" 규칙 추가
- 코드 내부의 변수명/상수만으로 외부 프로젝트의 의도를 판단하지 말고, 공식 소스(GitHub About, README, 릴리스 노트 등)와 교차 검증하도록 명시
- 코드 내부와 공식 소스가 충돌할 경우 공식 소스를 우선하도록 가이드

## Test plan

- [x] `~/.config/opencode/AGENTS.md`(실제 배포본)과 diff 비교 → 동일 확인
- [x] markdownlint 통과 확인 (0 error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)