### PR TITLE
docs: 중국어 단어 혼용 위반 예시 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ Conflict handling policy:
 - Mixed non-Korean terms in Korean: "가능한 대안方案" (X) → "가능한 대안 방안" (O)
 - Chinese characters in Korean text: "共青단 계열" (X) → "공산주의 청년단 계열" (O)
 - Translation-ese (awkward Korean from direct translation): "OWASP 표는 Prevention 컬럼이 너무 깽니다. 내용을 줄여서 정렬하겠습니다" (X) → "OWASP 표의 Prevention 컬럼 내용이 너무 깁니다. 줄여서 정렬하겠습니다" (O)
+- Chinese word in Korean text: "KMA API로迁移하고" (X) → "KMA API로 이관하고" 또는 "KMA API로 마이그레이션하고" (O)
 
 > When the user points out a violation, add that example to the list above.
 


### PR DESCRIPTION
## Summary

AGENTS.md의 "Communication Violation Examples" 섹션에 중국어 단어 혼용 사례를 추가했습니다.

## Changes

- `"KMA API로迁移하고" → "KMA API로 이관하고" 또는 "마이그레이션하고"` 예시 추가

## Context

실제 코드 리뷰 작성 중 발생한 위반 사례를 바탕으로 추가되었습니다. AGENTS.md 규칙에 따르면 한국어 문장에 중국어/일본어가 섞여서는 안 됩니다.

🤖 Generated with [OpenCode](https://github.com/ohmyopencode/opencode)